### PR TITLE
Remove redundant html

### DIFF
--- a/app/views/user_mailer/send_email.html.erb
+++ b/app/views/user_mailer/send_email.html.erb
@@ -1,12 +1,4 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-  </head>
-  <body>
     <h1>Sorry to inform you, <%= @recipient.name %></h1>
     <p><%= @user.name %> has passed away. <%= @user.name %> cared for you very much, and wanted to show you how they would like to be remembered.</p>
     <p> Here is a link to <%= @user.name %>'s   <a href =<%= @user_url %>> Memorial Page </a> </p>
     <p><%= @user.name %> designated <%= @executor.name %> as the executor of this memorial page, if you have any questions you can contact <%= @executor.name %> at <%= @executor.phone %> or <%= @executor.email %></p>
-  </body>
-</html>


### PR DESCRIPTION
Removed duplicated html from `send_email.html.erb`

This inherits from `mailer.html.erb` and so doesn't need the html formatting, but can just have the html that would go in the body. All tests pass. 

## Concerns

-  Any bugs still present?
-  Next steps?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor

## Checklist:
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.

## Issues: 
- [ ] Closes Issue #
